### PR TITLE
all: fix build

### DIFF
--- a/src/pkg/runtime/defs_akaros.go
+++ b/src/pkg/runtime/defs_akaros.go
@@ -17,7 +17,7 @@ package parlib
 #include <futex.h>
 #include <signal.h>
 #include <stdint.h>
-#include <benchutil/alarm.h>
+#include <parlib/alarm.h>
 #include <parlib/mcs.h>
 #include <parlib/parlib.h>
 #include <parlib/uthread.h>
@@ -34,8 +34,6 @@ package parlib
 import "C"
 
 const (
-	MAX_VCORES = C.MAX_VCORES
-
 	PROC_DUP_FGRP = C.PROC_DUP_FGRP
 
 	FUTEX_WAIT = C.FUTEX_WAIT

--- a/src/pkg/runtime/os_akaros.c
+++ b/src/pkg/runtime/os_akaros.c
@@ -54,7 +54,7 @@ runtime·newosproc(M *mp, void *stk)
 void
 runtime·osinit(void)
 {
-	runtime·ncpu = MIN(__procinfo.max_vcores, MAX_VCORES);
+	runtime·ncpu = MAX(__procinfo.max_vcores, 1);
 }
 
 void

--- a/src/pkg/runtime/parlib/gcc_akaros.h
+++ b/src/pkg/runtime/parlib/gcc_akaros.h
@@ -4,7 +4,7 @@
 
 #include <signal.h>
 #include <time.h>
-#include <benchutil/alarm.h>
+#include <parlib/alarm.h>
 #include <sys/syscall.h>
 
 typedef struct syscall gcc_syscall_arg_t;

--- a/src/pkg/runtime/parlib/syscall_akaros.go
+++ b/src/pkg/runtime/parlib/syscall_akaros.go
@@ -5,7 +5,7 @@
 package parlib
 
 /*
-#include <benchutil/alarm.h>
+#include <parlib/alarm.h>
 #include <parlib/uthread.h>
 #include <sys/syscall.h>
 

--- a/src/pkg/runtime/sys_akaros.c
+++ b/src/pkg/runtime/sys_akaros.c
@@ -226,17 +226,9 @@ int64 runtime·nanotime(void)
 #pragma textflag NOSPLIT
 void time·now(int64 sec, int32 nsec)
 {
-	int64 time;
-	static int64 boottime = 0;
-	if (!boottime) {
-		Timeval tv;
-		SyscallArg *sysc = (SyscallArg *)(g->sysc);
-		akaros_syscall(sysc, SYS_gettimeofday, &tv, 0, 0, 0, 0, 0, nil);
-		time = ((tv.tv_sec * 1000000LLU) + tv.tv_usec)*1000LLU;
-		boottime = time - tsc2nsec(runtime·cputicks());
-	} else {
-		time = boottime + tsc2nsec(runtime·cputicks());
-	}
+	// NOTE: we should add real time base to the nsec since start,
+	// but gettimeofday syscall is missing on akaros.
+	int64 time = tsc2nsec(runtime·cputicks());
 	sec = time / 1000000000LL;
 	nsec = time - sec * 1000000000LL;
 	FLUSH(&sec);

--- a/src/pkg/syscall/sysnumstubs_akaros_amd64.go
+++ b/src/pkg/syscall/sysnumstubs_akaros_amd64.go
@@ -56,7 +56,6 @@ const (
 	SYS_MKDIRAT                      = 351
 	SYS_MKNOD                        = 352
 	SYS_MKNODAT                      = 353
-	SYS_NANOSLEEP                    = 354
 	SYS_PAUSE                        = 355
 	SYS_PIVOT_ROOT                   = 356
 	SYS_PRLIMIT64                    = 357
@@ -117,4 +116,5 @@ const (
 	SYS_GETSOCKNAME                  = 415
 	SYS_RECVMSG                      = 416
 	SYS_SENDMSG                      = 417
+	SYS_PIPE                         = 1000
 )


### PR DESCRIPTION
Fix build for the latest akaros sources.
Tested with 6344ed04e307ba30df879d1d407b10a1b3236784 (Oct 5, 2017).

1. MAX_VCORES is not present in any akaros headers.
2. benchutil/alarm.h is moved to parlib/alarm.h.
3. SYS_gettimeofday does not exist anymore.
4. SYS_PIPE does not exist.
5. SYS_NANOSLEEP does exist now.

This now at least passes akaros.bash make,
and the resulting program actually started:

./testgo
Hello, Akaros!
fatal error: Exit Returned: We should never get here!

The exit crash is bad, but better than broken build.